### PR TITLE
refactor(RequestMapper): Adding unnecessary headers blows past node header limit.

### DIFF
--- a/src/request-forwarder.ts
+++ b/src/request-forwarder.ts
@@ -28,12 +28,12 @@ export class RequestForwarder {
           binaryTypes,
         ),
       );
+
       if (event.body) {
         const body = RequestMapper.getEventBody(event);
-        const flushed = req.write(body);
-        // tslint:disable-next-line: no-console
-        console.log(`INFO: AwsServerlessFastify Flush Status: ${flushed}`);
+        req.write(body);
       }
+
       req
         .on('error', error =>
           ResponseBuilder.buildConnectionErrorResponseToApiGateway(

--- a/src/request-mapper.ts
+++ b/src/request-mapper.ts
@@ -15,16 +15,6 @@ export class RequestMapper {
       headers['Content-Length'] = Buffer.byteLength(body);
     }
 
-    const clonedEventWithoutBody = RequestMapper.clone(JSON.stringify(event));
-    delete clonedEventWithoutBody.body;
-
-    headers['x-apigateway-event'] = encodeURIComponent(
-      JSON.stringify(clonedEventWithoutBody),
-    );
-    headers['x-apigateway-context'] = encodeURIComponent(
-      JSON.stringify(context),
-    );
-
     return {
       method: event.httpMethod,
       path: RequestMapper.getPathWithQueryStringParams(event),
@@ -41,9 +31,5 @@ export class RequestMapper {
 
   public static getEventBody(event: APIGatewayProxyEvent): Buffer {
     return Buffer.from(event.body, event.isBase64Encoded ? 'base64' : 'utf8');
-  }
-
-  private static clone(json: string): any {
-    return JSON.parse(JSON.stringify(json));
   }
 }


### PR DESCRIPTION
Fastify was returning HPE_HEADER_OVERFLOW