### PR TITLE
fix: use options object on instance.listen

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -21,7 +21,7 @@ describe('proxy()', () => {
     instance.get('/hello', async (request, reply) => {
       return exampleResponse;
     });
-    await instance.listen(sockFile);
+    await instance.listen({ path: sockFile });
     const response = await proxy(instance, event, context);
     expect(response.statusCode).toEqual(200);
     expect(JSON.parse(response.body)).toEqual(exampleResponse);

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,6 @@ function startFastify(
   instance: fastify.FastifyInstance,
   socketSuffix: string,
 ): Server {
-  instance.listen(SocketManager.getSocketPath(socketSuffix));
+  instance.listen({ path: SocketManager.getSocketPath(socketSuffix) });
   return instance.server;
 }


### PR DESCRIPTION
Fix the vardiac listen to use the optionsObject so that we do not get the following warning: 

[FSTDEP011] FastifyDeprecation: Variadic listen method is deprecated. Please use ".listen(optionsObject)" instead. The variadic signature will be removed in `fastify@5`